### PR TITLE
Update method to retrieve ClientInterface version

### DIFF
--- a/src/PortalBaseProvider.php
+++ b/src/PortalBaseProvider.php
@@ -67,7 +67,8 @@ class PortalBaseProvider extends AbstractProvider implements ProviderInterface
      */
     public function getAccessTokenResponse($code)
     {
-        $postKey = (version_compare(ClientInterface::VERSION, '6') === 1) ? 'form_params' : 'body';
+        $clientInterfaceVersion = defined('GuzzleHttp\ClientInterface::MAJOR_VERSION') ? ClientInterface::MAJOR_VERSION : ClientInterface::VERSION;
+        $postKey = (version_compare($clientInterfaceVersion, '6') === 1) ? 'form_params' : 'body';
 
         $response = $this->getHttpClient()->post($this->getTokenUrl(), [
             'auth' => [$this->clientId, $this->clientSecret],


### PR DESCRIPTION
Fixes #2.
GuzzleHttp\ClientInterface has removed the constant VERSION from version 7. This PR is proposed to make this repo accommodate different versions of GuzzleHttp\ClientInterface.